### PR TITLE
Remove CMP from ArgoCD CM and use it's own configuration

### DIFF
--- a/argocd/apps/argocd/values.yaml
+++ b/argocd/apps/argocd/values.yaml
@@ -36,20 +36,22 @@ argo-cd:
           secretName: argocd-cert-tls
   configs:
     cm:
-      configManagementPlugins: |
-        - name: kustomized-helm
-          init:
-            command: ["/bin/sh", "-c"]
-            args: ["helm dependency build"]
-          generate:
-            command: ["/bin/sh", "-c"]
-            args: ["helm template $ARGOCD_APP_NAME . > all.yaml && kustomize build"]
       resourceExclusions: |
         - apiGroups:
           - tekton.dev
           kinds:
           - PipelineRun
           - TaskRun
+    cmp:
+      create: true
+      plugins:
+        kustomized-helm:
+          init:
+            command: ["/bin/sh", "-c"]
+            args: ["helm dependency build"]
+          generate:
+            command: ["/bin/sh", "-c"]
+            args: ["helm template . --name-template $ARGOCD_APP_NAME --namespace $ARGOCD_APP_NAMESPACE --include-crds > all.yaml && kustomize build"]
     repositories:
       argo-helm-repo:
         url: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
This change removes the configuration from ArgoCD ConfigMap that will get deprecated in ([future releases](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/)).

Instead, will use it's new CRD provided by ArgoCD that uses a sidecar within repo-server component.